### PR TITLE
update container registry login example

### DIFF
--- a/Jenkinsfile.ext
+++ b/Jenkinsfile.ext
@@ -56,7 +56,7 @@ pipeline {
                                           passwordVariable: 'PASSWORD')]) {
                  sh """
                  #!/bin/bash
-                 docker login -u ${USERNAME} -p ${PASSWORD} ${env.REGISTRY_URL}
+                 docker login -u iamapikey -p ${PASSWORD} ${env.REGISTRY_URL}
                  docker push ${env.REGISTRY_URL}/${env.REGISTRY_NS}/pbw-mariadb-web:${env.MAJOR_PREFIX}.${env.BUILD_NUMBER}
                  """
              }


### PR DESCRIPTION
Follow IBM Cloud docs: https://cloud.ibm.com/docs/services/Registry?topic=registry-registry_access for signing in to container registry before pushing image.